### PR TITLE
chore: import repository https://github.com/ioachim-hub/minikube-jx-python-http.git

### DIFF
--- a/.jx/gitops/source-config.yaml
+++ b/.jx/gitops/source-config.yaml
@@ -9,6 +9,7 @@ spec:
     providerKind: github
     repositories:
     - name: jx3-python-demo
+    - name: minikube-jx-python-http
     scheduler: in-repo
   slack:
     channel: '#jenkins-x-pipelines'

--- a/config-root/namespaces/jx/lighthouse-config/config-cm.yaml
+++ b/config-root/namespaces/jx/lighthouse-config/config-cm.yaml
@@ -9,6 +9,7 @@ data:
       enabled:
         ioachim-hub/jx-minikube: true
         ioachim-hub/jx3-python-demo: true
+        ioachim-hub/minikube-jx-python-http: true
     plank: {}
     pod_namespace: jx
     prowjob_namespace: jx
@@ -22,6 +23,7 @@ data:
       merge_method:
         ioachim-hub/jx-minikube: merge
         ioachim-hub/jx3-python-demo: merge
+        ioachim-hub/minikube-jx-python-http: merge
       queries:
       - labels:
         - approved
@@ -34,6 +36,7 @@ data:
         repos:
         - ioachim-hub/jx-minikube
         - ioachim-hub/jx3-python-demo
+        - ioachim-hub/minikube-jx-python-http
       - labels:
         - updatebot
         missingLabels:
@@ -45,6 +48,7 @@ data:
         repos:
         - ioachim-hub/jx-minikube
         - ioachim-hub/jx3-python-demo
+        - ioachim-hub/minikube-jx-python-http
       target_url: http://lighthouse-jx.192.168.49.2.nip.io/merge/status
 kind: ConfigMap
 metadata:

--- a/config-root/namespaces/jx/lighthouse-config/plugins-cm.yaml
+++ b/config-root/namespaces/jx/lighthouse-config/plugins-cm.yaml
@@ -10,6 +10,10 @@ data:
       repos:
       - ioachim-hub/jx3-python-demo
       require_self_approval: true
+    - lgtm_acts_as_approve: true
+      repos:
+      - ioachim-hub/minikube-jx-python-http
+      require_self_approval: true
     cat: {}
     cherry_pick_unapproved: {}
     config_updater:
@@ -26,6 +30,11 @@ data:
       - endpoint: http://lighthouse-webui-plugin.jx.svc.cluster.local/lighthouse/events
         name: lighthouse-webui-plugin
       ioachim-hub/jx3-python-demo:
+      - endpoint: http://cd-indicators.jx.svc.cluster.local/lighthouse/events
+        name: cd-indicators
+      - endpoint: http://lighthouse-webui-plugin.jx.svc.cluster.local/lighthouse/events
+        name: lighthouse-webui-plugin
+      ioachim-hub/minikube-jx-python-http:
       - endpoint: http://cd-indicators.jx.svc.cluster.local/lighthouse/events
         name: cd-indicators
       - endpoint: http://lighthouse-webui-plugin.jx.svc.cluster.local/lighthouse/events
@@ -68,6 +77,22 @@ data:
       - cat
       - dog
       - pony
+      ioachim-hub/minikube-jx-python-http:
+      - approve
+      - assign
+      - blunderbuss
+      - help
+      - hold
+      - lgtm
+      - lifecycle
+      - override
+      - size
+      - trigger
+      - wip
+      - heart
+      - cat
+      - dog
+      - pony
     requiresig: {}
     sigmention: {}
     size:
@@ -82,6 +107,9 @@ data:
       trusted_org: todo
     - repos:
       - ioachim-hub/jx3-python-demo
+      trusted_org: todo
+    - repos:
+      - ioachim-hub/minikube-jx-python-http
       trusted_org: todo
     welcome:
     - message_template: Welcome

--- a/config-root/namespaces/jx/lighthouse/lighthouse-foghorn-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-foghorn-deploy.yaml
@@ -21,7 +21,7 @@ spec:
       labels:
         app: lighthouse-foghorn
       annotations:
-        jenkins-x.io/hash: 'b16d46ca61772a662bb1b458d2335987582bf4eb317b9018aee1299dbd99cc8e'
+        jenkins-x.io/hash: 'bb5f39e236b36b3228ab10714f06b20b0d7e5993278b21642c236d2fea80e769'
     spec:
       serviceAccountName: lighthouse-foghorn
       containers:

--- a/config-root/namespaces/jx/lighthouse/lighthouse-keeper-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-keeper-deploy.yaml
@@ -27,7 +27,7 @@ spec:
         ad.datadoghq.com/keeper.logs: '[{"source":"lighthouse","service":"keeper"}]'
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
-        jenkins-x.io/hash: 'b16d46ca61772a662bb1b458d2335987582bf4eb317b9018aee1299dbd99cc8e'
+        jenkins-x.io/hash: 'bb5f39e236b36b3228ab10714f06b20b0d7e5993278b21642c236d2fea80e769'
       labels:
         app: lighthouse-keeper
     spec:

--- a/config-root/namespaces/jx/lighthouse/lighthouse-tekton-controller-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-tekton-controller-deploy.yaml
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         app: lighthouse-tekton-controller
-      annotations: {jenkins-x.io/hash: 'b16d46ca61772a662bb1b458d2335987582bf4eb317b9018aee1299dbd99cc8e'}
+      annotations: {jenkins-x.io/hash: 'bb5f39e236b36b3228ab10714f06b20b0d7e5993278b21642c236d2fea80e769'}
     spec:
       serviceAccountName: lighthouse-tekton-controller
       containers:

--- a/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         prometheus.io/port: "2112"
         prometheus.io/scrape: "true"
-        jenkins-x.io/hash: 'b16d46ca61772a662bb1b458d2335987582bf4eb317b9018aee1299dbd99cc8e'
+        jenkins-x.io/hash: 'bb5f39e236b36b3228ab10714f06b20b0d7e5993278b21642c236d2fea80e769'
     spec:
       serviceAccountName: lighthouse-webhooks
       containers:

--- a/config-root/namespaces/jx/source-repositories/ioachim-hub-minikube-jx-python-http.yaml
+++ b/config-root/namespaces/jx/source-repositories/ioachim-hub-minikube-jx-python-http.yaml
@@ -1,0 +1,22 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: ioachim-hub
+    provider: github
+    repository: minikube-jx-python-http
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  name: ioachim-hub-minikube-jx-python-http
+  namespace: jx
+spec:
+  httpCloneURL: https://github.com/ioachim-hub/minikube-jx-python-http.git
+  org: ioachim-hub
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: minikube-jx-python-http
+  scheduler:
+    kind: ""
+    name: in-repo
+  url: https://github.com/ioachim-hub/minikube-jx-python-http


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the CI/CD configuration](https://jenkins-x.io/docs/v3/about/how-it-works/#importing--creating-quickstarts) which will create a second commit on this Pull Request before it auto merges
